### PR TITLE
Rc 0.14.2

### DIFF
--- a/keychain/private_keychain.py
+++ b/keychain/private_keychain.py
@@ -1,13 +1,11 @@
 from bitmerchant.wallet import Wallet as HDWallet
 from .public_keychain import PublicKeychain
 from binascii import unhexlify, hexlify
-from bitcoin import (
-    bip32_serialize,
-    encode_privkey as encode_private_key
-)
-from .utils import extract_bin_chain_path
+from .utils import extract_bin_chain_path, bip32_serialize
 from .configs import EXTENDED_PRIVATE_KEY_VERSION_BYTES as version_bytes
 
+import keylib
+from keylib.key_formatting import encode_privkey as encode_private_key
 
 class PrivateKeychain():
     def __init__(self, private_keychain=None):

--- a/keychain/public_keychain.py
+++ b/keychain/public_keychain.py
@@ -1,14 +1,12 @@
 from bitmerchant.wallet import (
     Wallet as HDWallet
 )
-from bitcoin import (
-    bip32_serialize,
-    encode_pubkey as encode_public_key
-)
 from binascii import hexlify, unhexlify
-from .utils import extract_bin_chain_path
+from .utils import extract_bin_chain_path, bip32_serialize
 from .configs import EXTENDED_PUBLIC_KEY_VERSION_BYTES as version_bytes
 
+import keylib
+from keylib.key_formatting import encode_pubkey as encode_public_key
 
 class PublicKeychain():
     def __init__(self, public_keychain):

--- a/keychain/utils.py
+++ b/keychain/utils.py
@@ -1,5 +1,12 @@
 from binascii import unhexlify
+from keylib.key_formatting import encode, decode, from_int_to_byte, from_byte_to_int, changebase, bin_dbl_sha256
 
+MAINNET_PRIVATE = b'\x04\x88\xAD\xE4'
+MAINNET_PUBLIC = b'\x04\x88\xB2\x1E'
+TESTNET_PRIVATE = b'\x04\x35\x83\x94'
+TESTNET_PUBLIC = b'\x04\x35\x87\xCF'
+PRIVATE = [MAINNET_PRIVATE, TESTNET_PRIVATE]
+PUBLIC = [MAINNET_PUBLIC, TESTNET_PUBLIC]
 
 def extract_bin_chain_path(chain_path):
     if len(chain_path) == 64:
@@ -8,3 +15,42 @@ def extract_bin_chain_path(chain_path):
         return chain_path
     else:
         raise ValueError('Invalid chain path')
+
+def hash_to_int(x):
+    if len(x) in [40, 64]:
+        # decode as hex string
+        return decode(x, 16)
+
+    # decode as byte string
+    return decode(x, 256)
+
+
+def bip32_serialize(rawtuple):
+    """
+    Derived from code from pybitcointools (https://github.com/vbuterin/pybitcointools)
+    by Vitalik Buterin
+    """
+    vbytes, depth, fingerprint, i, chaincode, key = rawtuple
+    i = encode(i, 256, 4)
+    chaincode = encode(hash_to_int(chaincode), 256, 32)
+    keydata = b'\x00'  +key[:-1] if vbytes in PRIVATE else key
+    bindata = vbytes + from_int_to_byte(depth % 256) + fingerprint + i + chaincode + keydata
+    return changebase(bindata + bin_dbl_sha256(bindata)[:4], 256, 58)
+
+
+def bip32_deserialize(data):
+    """
+    Derived from code from pybitcointools (https://github.com/vbuterin/pybitcointools)
+    by Vitalik Buterin
+    """
+    dbin = changebase(data, 58, 256)
+    if bin_dbl_sha256(dbin[:-4])[:4] != dbin[-4:]:
+        raise Exception("Invalid checksum")
+    vbytes = dbin[0:4]
+    depth = from_byte_to_int(dbin[4])
+    fingerprint = dbin[5:9]
+    i = decode(dbin[9:13], 256)
+    chaincode = dbin[13:45]
+    key = dbin[46:78]+b'\x01' if vbytes in PRIVATE else dbin[45:78]
+    return (vbytes, depth, fingerprint, i, chaincode, key)
+

--- a/setup.py
+++ b/setup.py
@@ -13,14 +13,14 @@ setup(
     url='https://github.com/blockstack/keychain-manager-py',
     license='MIT',
     author='Blockstack Developers',
-    author_email='hello@onename.com',
+    author_email='support@blockstack.com',
     description="""Library for BIP32 hierarchical deterministic keychains / wallets.""",
     keywords='bitcoin blockchain bip32 HD hierarchical deterministic keychain wallet',
     packages=find_packages(),
     zip_safe=False,
     install_requires=[
         'bitmerchant>=0.1.8',
-        'bitcoin>=1.1.42'
+        'keylib>=0.1.0',
     ],
     classifiers=[
         'Intended Audience :: Developers',

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='keychain',
-    version='0.1.4.1',
+    version='0.14.2.0',
     url='https://github.com/blockstack/keychain-manager-py',
     license='MIT',
     author='Blockstack Developers',

--- a/unit_tests.py
+++ b/unit_tests.py
@@ -3,8 +3,8 @@ import traceback
 import unittest
 from test import test_support
 from keychain import PrivateKeychain, PublicKeychain
-from bitcoin import bip32_deserialize, privkey_to_pubkey
-
+from keychain.utils import bip32_deserialize
+import keylib
 
 class BasicKeychainTest(unittest.TestCase):
     def setUp(self):
@@ -138,7 +138,8 @@ class HighVolumeKeyDerivationTest(unittest.TestCase):
         for i in range(len(keypairs)):
             keypair = keypairs[i]
             print "checking key %i of %i" % (i+1, number_of_keys)
-            self.assertEqual(privkey_to_pubkey(keypair['private']), keypair['public'])
+            # self.assertEqual(privkey_to_pubkey(keypair['private']), keypair['public'])
+            self.assertEqual(keylib.ECPrivateKey(keypair['private']).public_key().to_hex(), keylib.ECPublicKey(keypair['public']).to_hex())
 
 
 def test_main():


### PR DESCRIPTION
This release candidate removes the `pybitcointools` dependency by copying its implementation of `bip32_serialize` and `bip32_deserialize`, and relying on `keylib` for its encoding and decoding routines.  I also bumped the package version to `0.14.2` to keep it consistent with `virtualchain` and `blockstack`.